### PR TITLE
Quick Asia changes before hotfix

### DIFF
--- a/events/WTT_Japan.txt
+++ b/events/WTT_Japan.txt
@@ -1379,7 +1379,7 @@ country_event = {
 					}
 		
 					division_template = {
-						name = "People's Defence Force"
+						name = "Uibyeong"
 						is_locked = no
 						division_names_group = KOR_INF_01
 						priority = 0
@@ -1405,7 +1405,7 @@ country_event = {
 								is_in_home_area = yes
 							}
 							create_unit = {
-								division = "name = \"People's Defence Force\" division_template = \"People's Defence Force\" start_experience_factor = 1 start_equipment_factor = 1"
+								division = "name = \"Uibyeong\" division_template = \"Uibyeong\" start_experience_factor = 1 start_equipment_factor = 1"
 								owner = KOR
 							}
 						}

--- a/history/states/532-Nagoya.txt
+++ b/history/states/532-Nagoya.txt
@@ -1,0 +1,46 @@
+#####################################################################
+### DO NOT CHANGE FILE NAME, THIS IS AN OVERRIDE TO R56 / VANILLA ###
+#####################################################################
+
+state={
+	id=532
+	name="STATE_532" # Tokai
+	manpower = 6174000
+    
+	state_category = large_city
+	resources={
+		oil=2 #Sagara oil field.
+	}
+
+	history={
+		owner = JAP
+		add_core_of = JAP
+		buildings = {
+			infrastructure = 4 #was: 7
+			arms_factory = 1
+			dockyard = 1
+			industrial_complex = 2
+		}
+		
+		victory_points = {
+			7087 3 
+		}
+		
+		victory_points = {
+			10125 25
+		}
+		1939.1.1 = {
+			buildings = {
+				arms_factory = 2
+				industrial_complex = 3
+			}
+		}
+
+	}
+
+	provinces={
+		4069 4172 7087 7157 7187 10100 10125 12072 12097 
+	}
+
+	local_supplies=0.0 
+}

--- a/history/states/533-Akita.txt
+++ b/history/states/533-Akita.txt
@@ -1,0 +1,44 @@
+#####################################################################
+### DO NOT CHANGE FILE NAME, THIS IS AN OVERRIDE TO R56 / VANILLA ###
+#####################################################################
+
+state= {
+	id=533
+	name="STATE_533" # Tohoku
+	manpower = 6575000
+	
+	state_category = large_city
+	resources={
+		steel=27 # was: 35  no oil
+	}
+
+	history={
+		owner = JAP
+		add_core_of = JAP
+		buildings = {
+			infrastructure = 2 #was 3
+			arms_factory = 1
+			industrial_complex = 2
+			fuel_silo = 1
+			air_base = 6
+			9859 = {
+				naval_base = 6
+			}
+		}
+		
+		victory_points = {
+			6994 5
+		}
+		
+		victory_points = {
+			7169 15
+		}
+
+	}
+
+	provinces={
+		1024 1063 1165 3848 4067 4118 4122 4153 6870 6873 6994 7169 9807 9859 9865 11847 12056 
+	}
+
+	local_supplies=9.0
+}

--- a/history/states/534-Niigata.txt
+++ b/history/states/534-Niigata.txt
@@ -1,0 +1,36 @@
+#####################################################################
+### DO NOT CHANGE FILE NAME, THIS IS AN OVERRIDE TO R56 / VANILLA ###
+#####################################################################
+
+state={
+	id=534
+	name="STATE_534" # Hokuriku
+	manpower = 1933000
+	
+	state_category = city
+	resources={
+		oil=3 #was 1 and moved from Tohoku
+	}
+	history={
+		owner = JAP
+		add_core_of = JAP
+		buildings = {
+			infrastructure = 2 #was 4
+			arms_factory = 2
+			industrial_complex = 2
+			fuel_silo = 1
+		}
+		
+		victory_points = {
+			1117 10
+		}
+
+
+	}
+
+	provinces={
+		1117 9952 10128 11930 11989 12007 
+	}
+
+	local_supplies=0.0 
+}


### PR DESCRIPTION
Changes to names and oil.
-Changed names of spawned Korean units to Uibyeong (righteous army)
-Removed oil from Tohoku
-Added oil to Tokai
-Increased oil in Hokuriku