### PR TITLE
Biccy August 2024 

### DIFF
--- a/common/decisions/r56rp_formables.txt
+++ b/common/decisions/r56rp_formables.txt
@@ -35022,6 +35022,7 @@ AUS_viennas_reach_in_central_europe = {
 		fire_only_once = yes
 		cost = 25
 		available = {
+			controls_state = 1078
 			controls_state = 69
 		}
 		ai_will_do = {
@@ -35046,6 +35047,7 @@ AUS_viennas_reach_in_central_europe = {
 					OR = {
 						state = 69
 						state = 74
+						state = 1078
 					}
 				}
 				add_core_of = ROOT

--- a/common/national_focus/r56_gen_shared.txt
+++ b/common/national_focus/r56_gen_shared.txt
@@ -1856,6 +1856,13 @@
 				tag = WLS
 			}
 		}
+		offset = {
+			x = 52
+			y = 0
+			trigger = {
+				tag = LIE
+			}
+		}
 		cost = 10
 
 		available_if_capitulated = yes

--- a/common/national_focus/spain.txt
+++ b/common/national_focus/spain.txt
@@ -1226,8 +1226,6 @@ focus_tree = {
 
 	focus = {
 		id = SPA_primo_de_rivera_prisoner_exchange
-		available = {
-		}
 		bypass = {
 			has_global_flag = scw_over
 		}
@@ -1237,11 +1235,12 @@ focus_tree = {
 		x = 2
 		y = 1
 		relative_position_id = SPA_secure_the_national_defense_council
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
 		completion_reward = {
+			add_war_support = 0.05
 			custom_effect_tooltip = available_political_advisor
 			show_ideas_tooltip = SPA_jose_antonio_primo_de_rivera
 		}
@@ -2356,6 +2355,13 @@ focus_tree = {
 		available_if_capitulated = yes
 
 		completion_reward = {
+			every_state = {
+				limit = {
+					is_core_of = POR
+					is_controlled_by = ROOT
+				}
+				add_core_of = ROOT
+			}
 			if = {
 				limit = {
 					country_exists = BRA
@@ -2420,7 +2426,7 @@ focus_tree = {
             }			
 		}
 	}
-
+	
 	focus = {
 		id = SPA_claim_the_aragonese_possessions
 		available = {


### PR DESCRIPTION
I'll add more changes as I go, but this should probably be approved whenever you see it because the first fix is pretty important.

- The generic air tree for Liechtenstein no longer collides with the political focuses.
- Spain changes from the RT56 August update will join this mod.
- My Austrian formable menu has been updated to account for the Sudetenland being split.