### PR TITLE
Soviet air focus change

### DIFF
--- a/common/ideas/r56rp_ns_sov.txt
+++ b/common/ideas/r56rp_ns_sov.txt
@@ -41,7 +41,7 @@ ideas = {
 				army_core_defence_factor = 0.1
 			}
 		}
-		SOV_rt56rp_transpolar_flights_idea = {
+		SOV_r56rp_transpolar_flights_idea = {
 		
 			name = SOV_transpolar_flights_idea
 

--- a/common/ideas/r56rp_ns_sov.txt
+++ b/common/ideas/r56rp_ns_sov.txt
@@ -41,6 +41,38 @@ ideas = {
 				army_core_defence_factor = 0.1
 			}
 		}
+		SOV_rt56rp_transpolar_flights_idea = {
+		
+			name = SOV_transpolar_flights_idea
+
+			removal_cost = -1
+
+			available = {
+				has_war = no
+			}
+			
+			allowed = {
+				always = no # Added via focus
+			}
+
+			allowed_civil_war = {
+				always = no
+			}
+
+			picture = generic_air_bonus
+
+			modifier = {
+				air_ace_generation_chance_factor = 0.10
+				experience_gain_air = 0.10
+				air_doctrine_cost_factor = -0.05
+			}
+			
+			research_bonus = {
+				
+				air_equipment = 0.10
+			}
+
+		}
 	}
 }
 		

--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -2374,7 +2374,7 @@ focus_tree = {
 				category = air_doctrine
             }
 			add_timed_idea = {
-				idea = SOV_rt56rp_transpolar_flights_idea
+				idea = SOV_r56rp_transpolar_flights_idea
 				days = 435
 			}
 		}

--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -2374,7 +2374,7 @@ focus_tree = {
 				category = air_doctrine
             }
 			add_timed_idea = {
-				idea = SOV_transpolar_flights_idea
+				idea = SOV_rt56rp_transpolar_flights_idea
 				days = 435
 			}
 		}


### PR DESCRIPTION
Change the random research air doctrine bonus when its a legacy feature and currently not in use. Changed it to -5% air doctrine cost. Also changed the idea to a rt56rp one.

![Screenshot 2024-08-15 115007](https://github.com/user-attachments/assets/2debf95b-db3e-47cd-9a81-b8287ea41776)
